### PR TITLE
patches ext/api.js: parseMsg, _serialized

### DIFF
--- a/ext/js/api.js
+++ b/ext/js/api.js
@@ -119,8 +119,9 @@
 			/*
 			Parameters:
 				1. Sender of the message
-				2. Chat the message was sent at
+				2. Chat message was received from
 				3. Parsed Msg object
+				4. Msg object
 			*/
 			MESSAGE_RECEIVED: [],
 			
@@ -128,6 +129,7 @@
 			Parameters:
 				1. The chat the message was sent to
 				2. Parsed Msg object
+				3. Msg object
 			*/
 			MESSAGE_SENT: []
 		};
@@ -179,7 +181,7 @@
 					var chat = msg.__x_from;
 					var message = msg.__x_id._serialized;
 					console.log(msg);
-					API.listener.ExternalHandlers.MESSAGE_RECEIVED.forEach(x => x(sender, chat, API.parseMsgObject(msg)));
+					API.listener.ExternalHandlers.MESSAGE_RECEIVED.forEach(x => x(sender, chat, API.parseMsgObject(msg), msg));
 				}
 			},
 			/*
@@ -597,13 +599,15 @@
 			msg_object - the message object to convert to JSON compatible type
 		*/
 		parseMsgObject: function(msg_object) {
-			var m = msg_object.all;
-			if (msg_object["__x__quotedMsgObj"]) {
-				m.quotedMsg = API.parseMsgObject(Core.msg(msg_object.__x__quotedMsgObj.__x_id._serialized));
-			}
-			m.chat = m.chat.all;
-			delete m.msgChunk;
-			return m;
+			// var m = msg_object.all;
+			// if (msg_object["__x__quotedMsgObj"]) {
+			// 	m.quotedMsg = API.parseMsgObject(Core.msg(msg_object.__x__quotedMsgObj.__x_id._serialized));
+			// }
+			// m.chat = m.chat.all;
+			// delete m.msgChunk;
+			var m = msg_object;
+			var text_msg = (m.__x_text ? m.__x_text : "");
+			return text_msg;
 		},
 		
 		/*

--- a/ext/js/api.js
+++ b/ext/js/api.js
@@ -10,8 +10,11 @@
 		*/
 		group: function(_id) {
 			let result = null;
+			if (!(_id && _id._serialized))
+				return result;
+
 			Store.GroupMetadata.models.forEach(x => {
-				if (x.hasOwnProperty("__x_id") && x.__x_id == _id) {
+				if (x.hasOwnProperty("__x_id") && x.__x_id.hasOwnProperty("_serialized") && x.__x_id._serialized == _id._serialized) {
 					result = x;
 				}
 			});
@@ -23,8 +26,11 @@
 		*/
 		contact: function(_id) {
 			let result = null;
+			if (!(_id && _id._serialized))
+				return result;
+
 			Store.Contact.models.forEach(x => {
-				if (x.hasOwnProperty("__x_id") && x.__x_id == _id) {
+				if (x.hasOwnProperty("__x_id") && x.__x_id.hasOwnProperty("_serialized") && x.__x_id._serialized == _id._serialized) {
 					result = x;
 				}
 			});
@@ -36,8 +42,11 @@
 		*/
 		chat: function(_id) {
 			let result = null;
+			if (!(_id && _id._serialized))
+				return result;
+
 			Store.Chat.models.forEach(x => {
-				if (x.hasOwnProperty("__x_id") && x.__x_id == _id) {
+				if (x.hasOwnProperty("__x_id") && x.__x_id.hasOwnProperty("_serialized") && x.__x_id._serialized == _id._serialized) {
 					result = x;
 				}
 			});
@@ -49,8 +58,11 @@
 		*/
 		msg: function(_id) {
 			let result = null;
+			if (!(_id && _id._serialized))
+				return result;
+			
 			Store.Msg.models.forEach(x => {
-				if (x.hasOwnProperty("__x_id") && x.__x_id._serialized == _id) {
+				if (x.hasOwnProperty("__x_id") && x.__x_id.hasOwnProperty("_serialized") && x.__x_id._serialized == _id._serialized) {
 					result = x;
 				}
 			});


### PR DESCRIPTION
[89de903] 
Found error while receiving msg; I think the structure has been changed. cmiiw.

[eba3edb]
I think result item to find should be enough by matching to its `_serialized` value, instead of comparing the object it self.

Coz:
```
a = {s: "c.us", u: "foo", _sr: "foo@c.us"}, b = {s: "c.us", u: "foo", _sr: "foo@c.us"}; a == b;
false
a = {s: "c.us", u: "foo", _sr: "foo@c.us"}, b = {s: "c.us", u: "foo", _sr: "foo@c.us"}, c = a; a === c;
true
a = {s: "c.us", u: "foo", _sr: "foo@c.us"}, b = {s: "c.us", u: "foo", _sr: "foo@c.us"}; c = {ca: a, cb: "bar"}; a == c.ca;
true
```
But, there's no guarantee that `chat = msg.__x_from` (you have it from handler) is the EXACT same object like you are gonna look in `Store.Chat.models`..

